### PR TITLE
World Server Down Message & Character Screen Update

### DIFF
--- a/Server/WorldCluster/Handlers/WC.Handlers.Auth.vb
+++ b/Server/WorldCluster/Handlers/WC.Handlers.Auth.vb
@@ -614,6 +614,8 @@ Public Module WC_Handlers_Auth
 
                 Dim r As New PacketClass(OPCODES.SMSG_CHARACTER_LOGIN_FAILED)
                 r.AddInt8(AuthLoginCodes.CHAR_LOGIN_NO_WORLD)
+                r.AddInt8(AuthResponseCodes.REALM_LIST_REALM_NOT_FOUND)
+                r.AddInt8(AuthResponseCodes.CHAR_LIST_RETRIEVED)
                 Client.Send(r)
                 r.Dispose()
             End If
@@ -628,7 +630,7 @@ Public Module WC_Handlers_Auth
             r.AddInt8(AuthResponseCodes.CHAR_LOGIN_FAILED)
             Client.Send(r)
             r.Dispose()
-        End Try
+            End Try
 
     End Sub
     Public Sub On_CMSG_PLAYER_LOGOUT(ByRef packet As PacketClass, ByRef Client As ClientClass)


### PR DESCRIPTION
I managed to get the character selection screen to fresh after a world/map crash. This is the best I can get it for now. More work is needed to get the "World Down Message" to show up again. It just refreshes the session using a Realm List Update OpCode instead. Should have this working sometime in the near future.
