### PR TITLE
Migrate from System.Runtime.Remoting to SignalR

### DIFF
--- a/Bin/configs/WorldCluster.ini
+++ b/Bin/configs/WorldCluster.ini
@@ -55,19 +55,11 @@ Connection string format: SQLUser;SQLPass;SQLHost;SQLPort;SQLDatabase;SQLType
 ----------------------------------------------------------------------
 ---Cluster Link---
 ----------------------------------------------------------------------
--      ClusterPassword          - Password for remoting connections
--      ClusterListenMethod      - http/tcp/ipc (only if u know what u do!)
 -      ClusterListenHost        - Cluster host name or ip
 -      ClusterListenPort        - Cluster listen port
--      ClusterFirewall          - List your server IP (security)
 ----------------------------------------------------------------------
-<ClusterPassword>changeme</ClusterPassword>
-<ClusterListenMethod>tcp</ClusterListenMethod>
-<ClusterListenHost>localhost</ClusterListenHost>
+<ClusterListenHost>127.0.0.1</ClusterListenHost>
 <ClusterListenPort>50001</ClusterListenPort>
-<ClusterFirewall>
-	<IP>localhost</IP>
-</ClusterFirewall>
 
 ----------------------------------------------------------------------
 ---Stats file information---

--- a/Bin/configs/WorldServer.ini
+++ b/Bin/configs/WorldServer.ini
@@ -115,14 +115,10 @@ Connection string format: SQLUser;SQLPass;SQLHost;SQLPort;SQLDatabase;SQLType
 ----------------------------------------------------------------------
 ---Cluster Link---
 ----------------------------------------------------------------------
--      ClusterPassword          - Password for remoting connections
--      ClusterConnectMethod     - http/tcp/ipc (only if u know what u do!)
 -      ClusterConnectHost       - Cluster host name or ip
 -      ClusterConnectPort       - Cluster listen port
 ----------------------------------------------------------------------
-<ClusterPassword>changeme</ClusterPassword>
-<ClusterConnectMethod>tcp</ClusterConnectMethod>
-<ClusterConnectHost>localhost</ClusterConnectHost>
+<ClusterConnectHost>127.0.0.1</ClusterConnectHost>
 <ClusterConnectPort>50001</ClusterConnectPort>
 
 ----------------------------------------------------------------------
@@ -131,7 +127,7 @@ Connection string format: SQLUser;SQLPass;SQLHost;SQLPort;SQLDatabase;SQLType
 -      LocalConnectHost         - Local host name or ip
 -      LocalConnectPort         - Local listen port (AUTO or port number)
 ----------------------------------------------------------------------
-<LocalConnectHost>localhost</LocalConnectHost>
+<LocalConnectHost>127.0.0.1</LocalConnectHost>
 <LocalConnectPort>50002</LocalConnectPort>
 
 

--- a/Bin/configs/WorldServer1.ini
+++ b/Bin/configs/WorldServer1.ini
@@ -113,14 +113,10 @@ Connection string format: SQLUser;SQLPass;SQLHost;SQLPort;SQLDatabase;SQLType
 ----------------------------------------------------------------------
 ---Cluster Link---
 ----------------------------------------------------------------------
--      ClusterPassword          - Password for remoting connections
--      ClusterConnectMethod     - http/tcp/ipc (only if u know what u do!)
 -      ClusterConnectHost       - Cluster host name or ip
 -      ClusterConnectPort       - Cluster listen port
 ----------------------------------------------------------------------
-<ClusterPassword>changeme</ClusterPassword>
-<ClusterConnectMethod>tcp</ClusterConnectMethod>
-<ClusterConnectHost>localhost</ClusterConnectHost>
+<ClusterConnectHost>127.0.0.1</ClusterConnectHost>
 <ClusterConnectPort>50001</ClusterConnectPort>
 
 ----------------------------------------------------------------------
@@ -129,7 +125,7 @@ Connection string format: SQLUser;SQLPass;SQLHost;SQLPort;SQLDatabase;SQLType
 -      LocalConnectHost         - Local host name or ip
 -      LocalConnectPort         - Local listen port (AUTO or port number)
 ----------------------------------------------------------------------
-<LocalConnectHost>localhost</LocalConnectHost>
+<LocalConnectHost>127.0.0.1</LocalConnectHost>
 <LocalConnectPort>50002</LocalConnectPort>
 
 

--- a/Bin/configs/WorldServer2.ini
+++ b/Bin/configs/WorldServer2.ini
@@ -113,14 +113,10 @@ Connection string format: SQLUser;SQLPass;SQLHost;SQLPort;SQLDatabase;SQLType
 ----------------------------------------------------------------------
 ---Cluster Link---
 ----------------------------------------------------------------------
--      ClusterPassword          - Password for remoting connections
--      ClusterConnectMethod     - http/tcp/ipc (only if u know what u do!)
 -      ClusterConnectHost       - Cluster host name or ip
 -      ClusterConnectPort       - Cluster listen port
 ----------------------------------------------------------------------
-<ClusterPassword>changeme</ClusterPassword>
-<ClusterConnectMethod>tcp</ClusterConnectMethod>
-<ClusterConnectHost>localhost</ClusterConnectHost>
+<ClusterConnectHost>127.0.0.1</ClusterConnectHost>
 <ClusterConnectPort>50001</ClusterConnectPort>
 
 ----------------------------------------------------------------------
@@ -129,7 +125,7 @@ Connection string format: SQLUser;SQLPass;SQLHost;SQLPort;SQLDatabase;SQLType
 -      LocalConnectHost         - Local host name or ip
 -      LocalConnectPort         - Local listen port (AUTO or port number)
 ----------------------------------------------------------------------
-<LocalConnectHost>localhost</LocalConnectHost>
+<LocalConnectHost>127.0.0.1</LocalConnectHost>
 <LocalConnectPort>50003</LocalConnectPort>
 
 

--- a/MangosVB.props
+++ b/MangosVB.props
@@ -4,6 +4,6 @@
     <Company>getMaNGOS</Company>
     <Product>MaNGOSvb Server Pack</Product>
     <Copyright>Copyright (C) 2020, getMaNGOS</Copyright>
-    <Version>2.2.0.0</Version>
+    <Version>2.3.0.0</Version>
   </PropertyGroup>
 </Project>

--- a/MangosVB.sln
+++ b/MangosVB.sln
@@ -14,6 +14,8 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "WorldCluster", "Source\Worl
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "WorldServer", "Source\WorldServer\WorldServer.vbproj", "{936C7A31-3911-47B8-9B5A-AAAAB34AB522}"
 EndProject
+Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "SignalR", "Source\SignalR\SignalR.vbproj", "{8A1A2F45-0422-448B-A29B-2197357799AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{936C7A31-3911-47B8-9B5A-AAAAB34AB522}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{936C7A31-3911-47B8-9B5A-AAAAB34AB522}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{936C7A31-3911-47B8-9B5A-AAAAB34AB522}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8A1A2F45-0422-448B-A29B-2197357799AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8A1A2F45-0422-448B-A29B-2197357799AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8A1A2F45-0422-448B-A29B-2197357799AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8A1A2F45-0422-448B-A29B-2197357799AF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Common/Cluster.vb
+++ b/Source/Common/Cluster.vb
@@ -17,69 +17,43 @@
 '
 
 Imports System.ComponentModel
-Imports System.Collections.Generic
 Imports mangosVB.Shared
-
-Public Class Authenticator
-    Inherits MarshalByRefObject
-
-    Private ReadOnly _aObject As Object = Nothing
-    Private ReadOnly _aPassword As String = ""
-
-    Public Sub New(ByVal pObject As Object, ByVal pPassword As String)
-        _aPassword = pPassword
-        _aObject = pObject
-    End Sub
-
-    Public Function Login(ByVal password As String) As Object
-        If _aPassword = password Then
-            Return _aObject
-        Else
-            Return Nothing
-        End If
-    End Function
-
-    ' Make object live forever
-    Public Overrides Function InitializeLifetimeService() As Object
-        Return Nothing
-    End Function
-End Class
 
 Public Interface ICluster
 
-    <Description("Signal realm server for new world server.")> _
-    Function Connect(ByVal uri As String, ByVal maps As ICollection) As Boolean
-    <Description("Signal realm server for disconected world server.")> _
-    Sub Disconnect(ByVal uri As String, ByVal maps As ICollection)
+    <Description("Signal realm server for new world server.")>
+    Function Connect(ByVal uri As String, ByVal maps As ArrayList) As Boolean
+    <Description("Signal realm server for disconected world server.")>
+    Sub Disconnect(ByVal uri As String, ByVal maps As ArrayList)
 
-    <Description("Send data packet to client.")> _
+    <Description("Send data packet to client.")>
     Sub ClientSend(ByVal id As UInteger, ByVal data As Byte())
-    <Description("Notify client drop.")> _
+    <Description("Notify client drop.")>
     Sub ClientDrop(ByVal id As UInteger)
-    <Description("Notify client transfer.")> _
+    <Description("Notify client transfer.")>
     Sub ClientTransfer(ByVal id As UInteger, ByVal posX As Single, ByVal posY As Single, ByVal posZ As Single, ByVal ori As Single, ByVal map As UInteger)
-    <Description("Notify client update.")> _
+    <Description("Notify client update.")>
     Sub ClientUpdate(ByVal id As UInteger, ByVal zone As UInteger, ByVal level As Byte)
-    <Description("Set client chat flag.")> _
+    <Description("Set client chat flag.")>
     Sub ClientSetChatFlag(ByVal id As UInteger, ByVal flag As Byte)
-    <Description("Get client crypt key.")> _
+    <Description("Get client crypt key.")>
     Function ClientGetCryptKey(ByVal id As UInteger) As Byte()
 
     Function BattlefieldList(ByVal type As Byte) As List(Of Integer)
     Sub BattlefieldFinish(ByVal battlefieldId As Integer)
 
-    <Description("Send data packet to all clients online.")> _
+    <Description("Send data packet to all clients online.")>
     Sub Broadcast(ByVal data() As Byte)
-    <Description("Send data packet to all clients in specified client's group.")> _
+    <Description("Send data packet to all clients in specified client's group.")>
     Sub BroadcastGroup(ByVal groupId As Long, ByVal data() As Byte)
-    <Description("Send data packet to all clients in specified client's raid.")> _
+    <Description("Send data packet to all clients in specified client's raid.")>
     Sub BroadcastRaid(ByVal groupId As Long, ByVal data() As Byte)
-    <Description("Send data packet to all clients in specified client's guild.")> _
+    <Description("Send data packet to all clients in specified client's guild.")>
     Sub BroadcastGuild(ByVal guildId As Long, ByVal data() As Byte)
-    <Description("Send data packet to all clients in specified client's guild officers.")> _
+    <Description("Send data packet to all clients in specified client's guild officers.")>
     Sub BroadcastGuildOfficers(ByVal guildId As Long, ByVal data() As Byte)
 
-    <Description("Send update for the requested group.")> _
+    <Description("Send update for the requested group.")>
     Sub GroupRequestUpdate(ByVal id As UInteger)
 
 End Interface
@@ -103,8 +77,8 @@ Public Interface IWorld
     <Description("Respond to world server if still alive.")> _
     Function Ping(ByVal timestamp As Integer, ByVal latency As Integer) As Integer
 
-    <Description("Tell the cluster about your CPU & Memory Usage")> _
-    Sub ServerInfo(ByRef cpuUsage As Single, ByRef memoryUsage As ULong)
+    <Description("Tell the cluster about your CPU & Memory Usage")>
+    Function GetServerInfo() As ServerInfo
 
     <Description("Make world create specific map.")> _
     Sub InstanceCreate(ByVal Map As UInteger)
@@ -133,12 +107,18 @@ Public Interface IWorld
 
 End Interface
 
-<Serializable()> _
+<Serializable()>
 Public Class ClientInfo
     Public Index As UInteger
-    Public IP As Net.IPAddress
+    Public IP As String
     Public Port As UInteger
     Public Account As String
     Public Access As AccessLevel = AccessLevel.Player
     Public Expansion As ExpansionLevel = ExpansionLevel.NORMAL
 End Class
+
+Public Class ServerInfo
+    Public cpuUsage As Single
+    Public memoryUsage As ULong
+End Class
+

--- a/Source/SignalR/ProxyClient.vb
+++ b/Source/SignalR/ProxyClient.vb
@@ -1,0 +1,29 @@
+﻿Imports System.Reflection
+Imports Microsoft.AspNetCore.SignalR.Client
+
+Public Class ProxyClient
+    Inherits DispatchProxy
+
+    Private hubConnection As HubConnection
+
+    Protected Overrides Function Invoke(targetMethod As MethodInfo, args() As Object) As Object
+        If targetMethod.ReturnType.Name = "Void" Then
+            hubConnection.InvokeCoreAsync(targetMethod.Name, args).Wait()
+            Return Nothing
+        Else
+            Return hubConnection.InvokeCoreAsync(targetMethod.Name, targetMethod.ReturnType, args).Result
+        End If
+    End Function
+
+    Public Shared Function Create(Of T)(url As String) As T
+        Dim hubConnectionBuilder = New HubConnectionBuilder()
+        hubConnectionBuilder.WithUrl(url)
+        Dim hubConnection = hubConnectionBuilder.Build()
+        hubConnection.StartAsync().Wait()
+
+        Dim proxy = DispatchProxy.Create(Of T, ProxyClient)()
+        TryCast(proxy, ProxyClient).hubConnection = hubConnection
+        Return proxy
+    End Function
+
+End Class

--- a/Source/SignalR/ProxyServer.vb
+++ b/Source/SignalR/ProxyServer.vb
@@ -1,0 +1,30 @@
+﻿Imports System.Net
+Imports Microsoft.AspNetCore.Builder
+Imports Microsoft.AspNetCore.Hosting
+Imports Microsoft.AspNetCore.Http
+Imports Microsoft.AspNetCore.SignalR
+Imports Microsoft.Extensions.DependencyInjection
+
+Public Class ProxyServer(Of T As Hub)
+    Implements IDisposable
+
+    Private webhost As IWebHost
+
+    Sub New(address As IPAddress, port As Integer, hub As T)
+        Dim hostbuilder = New WebHostBuilder()
+        hostbuilder.UseKestrel(Sub(x) x.Listen(address, port))
+        hostbuilder.ConfigureServices(Sub(x As IServiceCollection) x.AddSignalR(AddressOf ConfigureSignalR))
+        hostbuilder.ConfigureServices(Sub(x As IServiceCollection) x.AddSingleton(hub))
+        hostbuilder.Configure(Sub(x As IApplicationBuilder) x.UseSignalR(Sub(y) y.MapHub(Of T)(New PathString(String.Empty))))
+        webhost = hostbuilder.Build()
+        webhost.Start()
+    End Sub
+
+    Private Sub ConfigureSignalR(hubOptions As HubOptions)
+        hubOptions.EnableDetailedErrors = True
+    End Sub
+
+    Public Sub Dispose() Implements IDisposable.Dispose
+        webhost.Dispose()
+    End Sub
+End Class

--- a/Source/SignalR/SignalR.vbproj
+++ b/Source/SignalR/SignalR.vbproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../MangosVB.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>    
+    <AssemblyTitle>SignalR</AssemblyTitle>
+    <AssemblyName>SignalR</AssemblyName>
+    <RootNamespace>SignalR</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.1.0" />
+    <PackageReference Include="System.Reflection.DispatchProxy" Version="4.7.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.vbproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/WorldCluster/Handlers/WC.Handlers.Misc.vb
+++ b/Source/WorldCluster/Handlers/WC.Handlers.Misc.vb
@@ -75,7 +75,9 @@ Namespace Handlers
                 Try
                     client.Character.GetWorld.ClientPacket(client.Index, packet.Data)
                 Catch
-                    WorldServer.Disconnect("NULL", New Integer() {client.Character.Map})
+                    Dim maps As New ArrayList
+                    maps.Add(client.Character.Map)
+                    WorldServer.Disconnect("NULL", maps)
                 End Try
             End If
         End Sub
@@ -90,7 +92,9 @@ Namespace Handlers
             Try
                 client.Character.GetWorld.ClientPacket(client.Index, packet.Data)
             Catch
-                WorldServer.Disconnect("NULL", New Integer() {client.Character.Map})
+                Dim maps As New ArrayList
+                maps.Add(client.Character.Map)
+                WorldServer.Disconnect("NULL", maps)
                 Exit Sub
             End Try
 
@@ -115,7 +119,9 @@ Namespace Handlers
                 Try
                     client.Character.GetWorld.ClientPacket(client.Index, packet.Data)
                 Catch
-                    WorldServer.Disconnect("NULL", New Integer() {client.Character.Map})
+                    Dim maps As New ArrayList
+                    maps.Add(client.Character.Map)
+                    WorldServer.Disconnect("NULL", maps)
                 End Try
             Else
                 Log.WriteLine(LogType.DEBUG, "[{0}:{1}] CMSG_CANCEL_TRADE", client.IP, client.Port)

--- a/Source/WorldCluster/WorldCluster.vb
+++ b/Source/WorldCluster/WorldCluster.vb
@@ -17,9 +17,11 @@
 '
 
 Imports System.IO
+Imports System.Net
 Imports System.Reflection
 Imports System.Threading
 Imports System.Xml.Serialization
+Imports SignalR
 
 Imports mangosVB.Common
 Imports mangosVB.Common.Globals
@@ -72,20 +74,12 @@ Public Module WorldCluster
         Private _worldDatabase As String = "root;mangosVB;localhost;3306;mangosVB;MySQL"
 
         'Cluster Settings
-        <XmlElement(ElementName:="ClusterPassword")>
-        Private _clusterPassword As String = ""
-
-        <XmlElement(ElementName:="ClusterListenMethod")>
-        Private _clusterListenMethod As String = "tcp"
 
         <XmlElement(ElementName:="ClusterListenAddress")>
         Private _clusterListenAddress As String = "127.0.0.1"
 
         <XmlElement(ElementName:="ClusterListenPort")>
         Private _clusterListenPort As Integer = 50001
-
-        <XmlArray(ElementName:="ClusterFirewall"), XmlArrayItem(GetType(String), ElementName:="IP")>
-        Private _firewall As New ArrayList
 
         'Stats Settings
         <XmlElement(ElementName:="StatsEnabled")>
@@ -187,34 +181,6 @@ Public Module WorldCluster
             End Set
         End Property
 
-        Property ClusterPassword As String
-            Get
-                Return _clusterPassword
-            End Get
-            Set(value As String)
-
-                If value Is Nothing Then
-                    Throw New ArgumentNullException(NameOf(value))
-                End If
-
-                _clusterPassword = value
-            End Set
-        End Property
-
-        Property ClusterListenMethod As String
-            Get
-                Return _clusterListenMethod
-            End Get
-            Set(value As String)
-
-                If value Is Nothing Then
-                    Throw New ArgumentNullException(NameOf(value))
-                End If
-
-                _clusterListenMethod = value
-            End Set
-        End Property
-
         Property ClusterListenAddress As String
             Get
                 Return _clusterListenAddress
@@ -235,20 +201,6 @@ Public Module WorldCluster
             End Get
             Set(value As Integer)
                 _clusterListenPort = value
-            End Set
-        End Property
-
-        Property Firewall As ArrayList
-            Get
-                Return _firewall
-            End Get
-            Set(value As ArrayList)
-
-                If value Is Nothing Then
-                    Throw New ArgumentNullException(NameOf(value))
-                End If
-
-                _firewall = value
             End Set
         End Property
 
@@ -578,6 +530,9 @@ Public Module WorldCluster
         End If
 
         WorldServer = New WorldServerClass
+        Dim server = New ProxyServer(Of WorldServerClass)(IPAddress.Parse(Config.ClusterListenAddress), Config.ClusterListenPort, WorldServer)
+        Log.WriteLine(LogType.INFORMATION, "Interface UP at: {0}:{1}", Config.ClusterListenAddress, Config.ClusterListenPort)
+
         GC.Collect()
 
         If Process.GetCurrentProcess().PriorityClass <> ProcessPriorityClass.High Then

--- a/Source/WorldCluster/WorldCluster.vbproj
+++ b/Source/WorldCluster/WorldCluster.vbproj
@@ -11,10 +11,8 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Runtime.Remoting" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Common\Common.vbproj" />
     <ProjectReference Include="..\Shared\Shared.vbproj" />
+    <ProjectReference Include="..\SignalR\SignalR.vbproj" />
   </ItemGroup>
 </Project>

--- a/Source/WorldServer/WorldServer.vbproj
+++ b/Source/WorldServer/WorldServer.vbproj
@@ -11,9 +11,6 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Runtime.Remoting" />
-  </ItemGroup>
-  <ItemGroup>
     <Import Include="Microsoft.VisualBasic" />
     <Import Include="mangosVB.Common" />
     <Import Include="System" />
@@ -26,6 +23,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Common\Common.vbproj" />
     <ProjectReference Include="..\Shared\Shared.vbproj" />
+    <ProjectReference Include="..\SignalR\SignalR.vbproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BigInteger" Version="1.0.7" />


### PR DESCRIPTION
Changes:
- Migrate from System.Runtime.Remoting to SignalR

Why do we need it:
System.Runtime.Remoting is not supporting for .NET Core

More info:
https://docs.microsoft.com/en-us/dotnet/core/porting/net-framework-tech-unavailable

@billy1arm 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangosvb/serverzero/137)
<!-- Reviewable:end -->
